### PR TITLE
Use both `babel` and `ember-cli-babel` in config.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -6,6 +6,8 @@ module.exports = function(defaults) {
   var app = new EmberApp(defaults, {
     'ember-cli-babel': {
       includePolyfill: false,
+    },
+    babel: {
       blacklist: [
         'es6.forOf',
         'regenerator',


### PR DESCRIPTION
Options to be passed through to babel itself (e.g. `blacklist`)
go into `babel` config key, and options for `ember-cli-babel`
(`includePolyfill` and `compileModules`) go in the
`ember-cli-babel` config key.